### PR TITLE
Fix redundant exception in schema manager

### DIFF
--- a/gemini_structured_response_prompts_database/schema_manager.py
+++ b/gemini_structured_response_prompts_database/schema_manager.py
@@ -81,9 +81,6 @@ class SchemaManager:
                 raise HTTPException(
                     status_code=404, detail=f"Schema not found for id: {prompt_id}"
                 )
-                raise HTTPException(
-                    status_code=404, detail=f"Schema not found for type: {prompt_type}"
-                )
             return self._db_to_pydantic(result)
         except Exception as e:
             logger.error(f"Error getting schema: {str(e)}")


### PR DESCRIPTION
## Summary
- remove unreachable 404 block from `get_prompt_schema`

## Testing
- `pytest -q`
- `black --check gemini_structured_response_prompts_database/schema_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6850cb3d5710832f9495ecf3d4fc3095